### PR TITLE
Silence debug toolbar and URLField warnings

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -44,6 +44,11 @@ DATABASES = {
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
+# Opt-in to Django 6.0's default HTTPS scheme for URL fields now so that forms
+# that rely on the default URLField configuration do not emit transitional
+# warnings during tests.
+FORMS_URLFIELD_ASSUME_HTTPS = True
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -48,7 +48,6 @@ DEBUG_TOOLBAR_PANELS = (
     "template_timings_panel.panels.TemplateTimings.TemplateTimings",
     "debug_toolbar.panels.cache.CachePanel",
     "debug_toolbar.panels.headers.HeadersPanel",
-    "debug_toolbar.panels.logging.LoggingPanel",
     "debug_toolbar.panels.profiling.ProfilingPanel",
     "debug_toolbar.panels.redirects.RedirectsPanel",
     "debug_toolbar.panels.request.RequestPanel",


### PR DESCRIPTION
## Summary
- remove the deprecated logging panel from the debug toolbar panel list
- opt into Django's upcoming default HTTPS URLField scheme to silence warnings

## Testing
- `pytest bordercore/blob/tests/test_forms.py::test_blob_form_add` *(fails: missing boto3 dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec258c2108327945e794fb986e40d