### PR TITLE
Add https default scheme to URL fields in models

### DIFF
--- a/bordercore/bookmark/models.py
+++ b/bordercore/bookmark/models.py
@@ -41,7 +41,7 @@ class DailyBookmarkJSONField(JSONField):
 
 class Bookmark(TimeStampedModel):
     uuid = models.UUIDField(default=uuid.uuid4, editable=False)
-    url = models.URLField(max_length=1000)
+    url = models.URLField(max_length=1000, assume_scheme="https")
     name = models.TextField()
     user = models.ForeignKey(User, on_delete=models.PROTECT)
     note = models.TextField(null=True)

--- a/bordercore/feed/models.py
+++ b/bordercore/feed/models.py
@@ -19,10 +19,10 @@ log = logging.getLogger(f"bordercore.{__name__}")
 class Feed(TimeStampedModel):
     uuid = models.UUIDField(default=uuid.uuid4, editable=False)
     name = models.TextField()
-    url = models.URLField(unique=True)
+    url = models.URLField(unique=True, assume_scheme="https")
     last_check = models.DateTimeField(null=True)
     last_response_code = models.IntegerField(null=True)
-    homepage = models.URLField(null=True)
+    homepage = models.URLField(null=True, assume_scheme="https")
     verify_ssl_certificate = models.BooleanField(default=True)
     user = models.ForeignKey(User, on_delete=models.PROTECT)
 

--- a/bordercore/todo/models.py
+++ b/bordercore/todo/models.py
@@ -39,7 +39,7 @@ class Todo(TimeStampedModel):
     uuid: models.UUIDField = models.UUIDField(default=uuid.uuid4, editable=False)
     name = models.TextField()
     note = models.TextField(null=True, blank=True)
-    url = models.URLField(max_length=1000, null=True, blank=True)
+    url = models.URLField(max_length=1000, null=True, blank=True, assume_scheme="https")
     user = models.ForeignKey(User, on_delete=models.PROTECT)
     tags = models.ManyToManyField(Tag)
     data = JSONField(null=True, blank=True)


### PR DESCRIPTION
## Summary
- add `assume_scheme="https"` to URLField declarations across bookmark, feed, and todo models to ensure HTTPS defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df124ea4348327a9806ae16b4b1d61