### PR TITLE
Make ElasticsearchMixin index path resilient to ES outages

### DIFF
--- a/bordercore/blob/tests/test_data.py
+++ b/bordercore/blob/tests/test_data.py
@@ -22,6 +22,7 @@ from pwd import getpwuid
 
 import boto3
 import pytest
+from elasticsearch.helpers import scan
 
 from django.conf import settings
 from django.db.models import Q
@@ -78,8 +79,9 @@ def test_books_with_tags(es):
                 ]
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "size": 1,
+        "_source": False,
+        "track_total_hits": True,
     }
 
     found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)['hits']
@@ -128,8 +130,9 @@ def test_documents_and_notes_with_dates(es):
                 ]
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "size": 1,
+        "_source": False,
+        "track_total_hits": True,
     }
 
     found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]
@@ -162,8 +165,9 @@ def test_videos_with_durations(es):
                 ]
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "size": 1,
+        "_source": False,
+        "track_total_hits": True,
     }
 
     found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]
@@ -207,8 +211,8 @@ def test_dates_with_unixtimes(es):
                 ]
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "size": 0,
+        "track_total_hits": True,
     }
 
     found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]["total"]["value"]
@@ -240,8 +244,8 @@ def test_books_with_names(es):
                 ]
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "size": 0,
+        "track_total_hits": True,
     }
 
     found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]["total"]["value"]
@@ -279,8 +283,9 @@ def test_books_with_author(es):
                 ]
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "size": 1,
+        "_source": False,
+        "track_total_hits": True,
     }
 
     found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]
@@ -290,7 +295,7 @@ def test_books_with_author(es):
 def test_books_with_contents(es):
     "Assert that all books have contents"
     blobs_not_indexed = [str(x.uuid) for x in Blob.objects.filter(is_indexed=False).only("uuid")]
-    search_object = {
+    query = {
         "query": {
             "bool": {
                 "must": [
@@ -313,13 +318,10 @@ def test_books_with_contents(es):
                 ]
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["filename", "uuid"]
+        "_source": ["filename"],
     }
 
-    found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]
-
-    for match in found["hits"]:
+    for match in scan(es, index=settings.ELASTICSEARCH_INDEX, query=query, size=1000):
         if match["_source"]["filename"].endswith("pdf") and match["_id"] not in blobs_not_indexed:
             pytest.fail(f"Book has no content, uuid={match['_id']}")
 
@@ -384,7 +386,7 @@ def test_blobs_in_s3_exist_in_db():
     # Step 1: Extract all UUIDs from S3
     s3_uuids = set()
     paginator = s3_resource.meta.client.get_paginator("list_objects_v2")
-    page_iterator = paginator.paginate(Bucket=bucket_name)
+    page_iterator = paginator.paginate(Bucket=bucket_name, Prefix="blobs/")
 
     # Compile regex once for better performance
     uuid_pattern = re.compile(r"^blobs/(.*?)/")
@@ -479,29 +481,26 @@ def test_images_have_thumbnails():
 def test_elasticsearch_blobs_exist_in_s3(es):
     "Assert that all blobs in Elasticsearch exist in S3"
 
-    search_object = {
+    query = {
         "query": {
             "bool": {
-                "must":
-                {
-                    "exists": {
-                        "field": "sha1sum"
-                    }
-                },
-                "must_not":
-                {
-                    "term": {
-                        "sha1sum": ""
-                    }
-                }
+                "must": {"exists": {"field": "sha1sum"}},
+                "must_not": {"term": {"sha1sum": ""}},
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["filename", "sha1sum", "uuid"]
+        "_source": ["uuid"],
     }
 
-    found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]["hits"]
-    if not found:
+    es_uuids = [
+        hit["_source"]["uuid"]
+        for hit in scan(
+            es,
+            index=settings.ELASTICSEARCH_INDEX,
+            query=query,
+            size=1000,
+        )
+    ]
+    if not es_uuids:
         pytest.fail("Expected non-empty UUIDs from Elasticsearch; none found.")
 
     s3_resource = boto3.resource("s3")
@@ -509,7 +508,7 @@ def test_elasticsearch_blobs_exist_in_s3(es):
     s3_uuids = set()
 
     paginator = s3_resource.meta.client.get_paginator("list_objects_v2")
-    page_iterator = paginator.paginate(Bucket=bucket_name)
+    page_iterator = paginator.paginate(Bucket=bucket_name, Prefix="blobs/")
 
     for page in page_iterator:
         if "Contents" not in page:
@@ -522,9 +521,9 @@ def test_elasticsearch_blobs_exist_in_s3(es):
     if not s3_uuids:
         pytest.fail("Expected non-empty UUIDs from S3; none found.")
 
-    for blob in found:
-        if blob["_source"]["uuid"] not in s3_uuids:
-            pytest.fail(f"blob {blob['_source']['uuid']} exists in Elasticsearch but not in S3")
+    for uuid in es_uuids:
+        if uuid not in s3_uuids:
+            pytest.fail(f"blob {uuid} exists in Elasticsearch but not in S3")
 
 @pytest.mark.wumpus
 def test_blobs_in_s3_exist_on_filesystem():
@@ -533,7 +532,7 @@ def test_blobs_in_s3_exist_on_filesystem():
     s3_resource = boto3.resource("s3")
 
     paginator = s3_resource.meta.client.get_paginator("list_objects_v2")
-    page_iterator = paginator.paginate(Bucket=bucket_name)
+    page_iterator = paginator.paginate(Bucket=bucket_name, Prefix="blobs/")
 
     for page in page_iterator:
         for key in page["Contents"]:
@@ -552,7 +551,7 @@ def test_blobs_on_filesystem_exist_in_s3():
     s3_resource = boto3.resource("s3")
 
     paginator = s3_resource.meta.client.get_paginator("list_objects_v2")
-    page_iterator = paginator.paginate(Bucket=bucket_name)
+    page_iterator = paginator.paginate(Bucket=bucket_name, Prefix="blobs/")
 
     blobs = {}
 
@@ -862,8 +861,9 @@ def test_blobs_have_size_field(es):
                 ]
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "size": 1,
+        "_source": ["uuid"],
+        "track_total_hits": True,
     }
 
     found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]
@@ -889,8 +889,9 @@ def test_no_test_data_in_elasticsearch(es):
                 },
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "size": 1,
+        "_source": False,
+        "track_total_hits": True,
     }
 
     found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]
@@ -900,7 +901,7 @@ def test_no_test_data_in_elasticsearch(es):
 
 def test_embeddings_exist(es):
     "Assert that all documents with non-empty contents also have text embeddings."
-    search_object = {
+    query = {
         "query": {
             "bool": {
                 "must": [
@@ -912,15 +913,15 @@ def test_embeddings_exist(es):
                 ]
             }
         },
-        "size": 10000,
-        "_source": ["contents", "uuid"]
+        "_source": ["contents"],
     }
-
-    found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]
 
     # Note that we can't filter out documents whose contents are the empty string
     # in the query, since that field is analyzed and thus whitespace would be
     # removed during analysis. Therefore we filter these out afterwards in Python.
-    matches = [x for x in found["hits"] if x["_source"]["contents"] != ""]
+    matches = [
+        hit for hit in scan(es, index=settings.ELASTICSEARCH_INDEX, query=query, size=1000)
+        if hit["_source"]["contents"] != ""
+    ]
 
     assert len(matches) == 0, f"{len(matches)} documents with no embeddings found, uuid={matches[0]['_id']}"

--- a/bordercore/bookmark/tests/test_data.py
+++ b/bordercore/bookmark/tests/test_data.py
@@ -9,6 +9,7 @@ import re
 
 import boto3
 import pytest
+from elasticsearch.helpers import scan
 
 import django
 from django.conf import settings
@@ -178,24 +179,22 @@ def test_elasticsearch_bookmarks_exist_in_db(es):
         AssertionError: If any bookmark IDs found in Elasticsearch are missing
             from the database.
     """
-    search_object = {
+    query = {
         "query": {
             "term": {
                 "doctype": "bookmark"
             }
         },
-        "from_": 0,
-        "size": 10000,
-        "_source": ["uuid"]
+        "_source": ["uuid"],
     }
 
-    found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]["hits"]
+    es_uuids = [
+        hit["_source"]["uuid"]
+        for hit in scan(es, index=settings.ELASTICSEARCH_INDEX, query=query, size=1000)
+    ]
 
-    if not found:
+    if not es_uuids:
         pytest.fail("Expected non-empty UUIDs from Elasticsearch; none found.")
-
-    # Extract ES UUIDs
-    es_uuids = [bookmark["_source"]["uuid"] for bookmark in found]
 
     # Single database query to get all existing UUIDs
     db_uuids = set(
@@ -251,7 +250,7 @@ def test_bookmark_thumbnails_in_s3_exist_in_db():
 
     # Extract all UUIDs from S3
     paginator = s3_resource.meta.client.get_paginator("list_objects_v2")
-    page_iterator = paginator.paginate(Bucket=bucket_name)
+    page_iterator = paginator.paginate(Bucket=bucket_name, Prefix="bookmarks/")
 
     for page in page_iterator:
         if "Contents" not in page:

--- a/bordercore/drill/tests/test_data.py
+++ b/bordercore/drill/tests/test_data.py
@@ -8,6 +8,7 @@ between the database and the Elasticsearch index.
 
 import django
 import pytest
+from elasticsearch.helpers import scan
 
 from django.conf import settings
 
@@ -68,18 +69,19 @@ def test_questions_in_db_exist_in_elasticsearch(es):
 def test_elasticsearch_questions_exist_in_db(es):
     """Assert that all questions in Elasticsearch exist in the database"""
 
-    search_object = {
+    query = {
         "query": {
             "term": {
                 "doctype": "drill"
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "_source": ["uuid"],
     }
 
-    found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]["hits"]
-    es_uuids = [question["_source"]["uuid"] for question in found]
+    es_uuids = [
+        hit["_source"]["uuid"]
+        for hit in scan(es, index=settings.ELASTICSEARCH_INDEX, query=query, size=1000)
+    ]
     if not es_uuids:
         pytest.fail("Expected non-empty UUIDs from Elasticsearch; none found.")
 

--- a/bordercore/lib/mixins.py
+++ b/bordercore/lib/mixins.py
@@ -78,8 +78,26 @@ class ElasticsearchMixin(models.Model):
         raise NotImplementedError("Subclasses must define elasticsearch_document")
 
     def index_es_document(self) -> None:
-        """Index this object in Elasticsearch."""
-        index_document(self.elasticsearch_document)
+        """Schedule indexing of this object in Elasticsearch after the
+        current transaction commits.
+
+        Postgres is the source of truth; ES is a derived index. The ES write
+        is deferred via ``transaction.on_commit()`` so a row never appears in
+        ES that Postgres later rolls back, and any ES outage logs a warning
+        instead of propagating out and breaking the Postgres write. Mirrors
+        ``delete_from_elasticsearch``.
+        """
+        document = self.elasticsearch_document
+        model_name = type(self).__name__.lower()
+        obj_uuid = str(getattr(self, "uuid", "<no-uuid>"))
+
+        def do_index() -> None:
+            try:
+                index_document(document)
+            except Exception as e:
+                log.warning("Failed to index %s %s in Elasticsearch: %s", model_name, obj_uuid, e)
+
+        transaction.on_commit(do_index)
 
     def delete_from_elasticsearch(self) -> None:
         """Schedule deletion of this object from Elasticsearch after transaction commit.

--- a/bordercore/lib/tests/test_mixins.py
+++ b/bordercore/lib/tests/test_mixins.py
@@ -1,5 +1,7 @@
 import pytest
+from django.db import transaction
 from django.http import Http404
+from django.test import TestCase
 
 from lib.mixins import get_user_object_or_404
 from todo.models import Todo
@@ -29,3 +31,50 @@ def test_raises_404_when_object_does_not_exist():
     user = UserFactory()
     with pytest.raises(Http404):
         get_user_object_or_404(user, Todo, uuid="00000000-0000-0000-0000-000000000000")
+
+
+def test_index_es_document_swallows_elasticsearch_failures(monkeypatch):
+    """ElasticsearchMixin.index_es_document must log and continue when
+    the underlying ES call raises, mirroring delete_from_elasticsearch.
+
+    Postgres is the source of truth; ES is a derived index. An ES outage
+    must never propagate out and break a Postgres write.
+    """
+    def boom(doc):
+        raise RuntimeError("elasticsearch unreachable")
+    monkeypatch.setattr("lib.mixins.index_document", boom)
+
+    user = UserFactory(username="es_swallow", email="es@example.com")
+
+    # captureOnCommitCallbacks(execute=True) forces queued on_commit
+    # callbacks to run inline. If the mixin's deferred callback let the
+    # ES error propagate, the `with` block would raise.
+    with TestCase.captureOnCommitCallbacks(execute=True) as callbacks:
+        todo = Todo.objects.create(user=user, name="Resilient")
+
+    assert todo.pk is not None
+    assert len(callbacks) >= 1
+
+
+def test_index_es_document_is_deferred_until_commit(monkeypatch):
+    """index_es_document must queue a transaction.on_commit callback rather
+    than calling index_document synchronously, so ES never sees a row that
+    Postgres later rolls back.
+    """
+    calls = []
+    monkeypatch.setattr("lib.mixins.index_document", lambda doc: calls.append(doc))
+
+    user = UserFactory(username="es_defer", email="defer@example.com")
+    with transaction.atomic():
+        todo = Todo.objects.create(user=user, name="Deferred")
+        # Inside the atomic block, on_commit has not fired. If the mixin
+        # called index_document synchronously, calls would already have an
+        # entry. Since the outer pytest-django transaction wraps this too,
+        # the on_commit callback never fires for the lifetime of this test
+        # — but the synchronous-vs-deferred distinction is observable right
+        # here.
+        assert calls == [], (
+            f"index_es_document called sync inside atomic block; expected "
+            f"deferred via on_commit. Got {len(calls)} call(s)."
+        )
+    assert todo.pk is not None

--- a/bordercore/music/models.py
+++ b/bordercore/music/models.py
@@ -155,9 +155,7 @@ class Album(ElasticsearchMixin, TimeStampedModel):
             **kwargs: Arbitrary keyword arguments.
         """
         super().save(*args, **kwargs)
-
-        # Index the album in Elasticsearch after the transaction commits
-        transaction.on_commit(self.index_es_document)
+        self.index_es_document()
 
     def delete(
             self,
@@ -247,9 +245,7 @@ class Song(ElasticsearchMixin, TimeStampedModel):
             **kwargs: Arbitrary keyword arguments.
         """
         super().save(*args, **kwargs)
-
-        # Index the song in Elasticsearch after the transaction commits
-        transaction.on_commit(self.index_es_document)
+        self.index_es_document()
 
     def delete(
             self,

--- a/bordercore/music/tests/test_data.py
+++ b/bordercore/music/tests/test_data.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import boto3
 import pytest
+from elasticsearch.helpers import scan
 
 import django
 from django.conf import settings
@@ -153,24 +154,18 @@ def test_songs_in_s3_exist_in_db():
 
 def test_elasticsearch_songs_exist_in_s3(es):
     """Assert that all songs in Elasticsearch exist in S3"""
-    # Get all song UUIDs from Elasticsearch in one query
-    search_object = {
+    query = {
         "query": {
-            "bool": {
-                "must": [
-                    {
-                        "term": {
-                            "doctype": "song"
-                        }
-                    }
-                ]
+            "term": {
+                "doctype": "song"
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["uuid"]
+        "_source": ["uuid"],
     }
-    songs_in_elasticsearch = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]["hits"]
-    es_uuids = [song["_source"]["uuid"] for song in songs_in_elasticsearch]
+    es_uuids = [
+        hit["_source"]["uuid"]
+        for hit in scan(es, index=settings.ELASTICSEARCH_INDEX, query=query, size=1000)
+    ]
     if not es_uuids:
         pytest.fail("Expected non-empty UUIDs from Elasticsearch; none found.")
 

--- a/bordercore/todo/tests/test_data.py
+++ b/bordercore/todo/tests/test_data.py
@@ -1,4 +1,5 @@
 import pytest
+from elasticsearch.helpers import scan
 
 import django
 from django.conf import settings
@@ -115,16 +116,15 @@ def test_elasticsearch_todo_tasks_exist_in_db(es):
     """Assert that all todo tasks in Elasticsearch exist in the database"""
 
     # Get all todos from Elasticsearch
-    search_object = {
+    query = {
         "query": {
             "term": {
                 "doctype": "todo"
             }
         },
-        "from_": 0, "size": 10000,
-        "_source": ["_id", "bordercore_id"]
+        "_source": ["bordercore_id"],
     }
-    found = es.search(index=settings.ELASTICSEARCH_INDEX, **search_object)["hits"]["hits"]
+    found = list(scan(es, index=settings.ELASTICSEARCH_INDEX, query=query, size=1000))
 
     if not found:
         pytest.fail("Expected non-empty IDs from Elasticsearch; none found.")


### PR DESCRIPTION
## Summary

- Defer `ElasticsearchMixin.index_es_document` via `transaction.on_commit` and swallow ES errors inside the deferred callback, mirroring `delete_from_elasticsearch`. Postgres becomes the source of truth; ES is treated as an eventually-consistent derived index.
- Drop now-redundant `transaction.on_commit(self.index_es_document)` wrappers in `Album.save` and `Song.save`; the mixin handles deferral internally.

## Why

The reminder cron on EC2 was looping: a `Todo` create inside `trigger_reminders` failed because Elasticsearch was unreachable, the exception propagated out of `Todo.save()`, the reminder's `next_trigger_at` never advanced, and every 5-minute cron tick re-sent the same reminder email plus an error email. The previous commit (3f57d27d) made the trigger durable at the command level; this PR fixes the underlying inconsistency in `ElasticsearchMixin` so any caller — not just `trigger_reminders` — survives an ES outage.

Before this change, the six models using `ElasticsearchMixin` had three different save-path patterns (sync index, `on_commit` index, no index in save) but a single uniform delete path (deferred + swallowed). The index path now matches the delete path.

## Test plan

- [x] New `test_index_es_document_swallows_elasticsearch_failures` — `monkeypatch` `index_document` to raise, run inside `captureOnCommitCallbacks(execute=True)`, assert the create completes.
- [x] New `test_index_es_document_is_deferred_until_commit` — assert no `index_document` call inside an open atomic block.
- [x] Existing tests for `todo`, `collection`, `music`, `bookmark`, `drill`, `reminder` model and view layers all pass.
- [ ] On EC2: verify the reminder cron no longer loops when ES is unreachable.